### PR TITLE
Add user profile refresh on tenant switch

### DIFF
--- a/src/app/(auth)/tenant-selector/page.tsx
+++ b/src/app/(auth)/tenant-selector/page.tsx
@@ -27,6 +27,7 @@ function TenantSelectorContent() {
   const searchParams = useSearchParams()
   const [showCreateForm, setShowCreateForm] = useState(false)
   const [isRefreshing, setIsRefreshing] = useState(false)
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
 
   // Get the force parameter from URL, default to true to prevent auto-redirect
   const forceStay = searchParams.get('force') !== 'false'
@@ -109,6 +110,7 @@ function TenantSelectorContent() {
   // Handle successful organization creation
   const handleOrganizationCreated = (slug: string) => {
     refresh() // Refresh the list first (in case user wants to create another)
+    setIsDialogOpen(false) // Close the dialog
 
     // Only auto-navigate if not forcing to stay on this page
     if (!shouldStayOnPage) {
@@ -218,7 +220,7 @@ function TenantSelectorContent() {
             </div>
 
             {/* Create new organization */}
-            <Dialog>
+            <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
               <DialogTrigger asChild>
                 <Button variant="outline" className="w-full mt-4 border-dashed">
                   <PlusCircle className="mr-2 h-4 w-4" />
@@ -232,7 +234,10 @@ function TenantSelectorContent() {
                     Create a new organization unit to manage your automation processes.
                   </DialogDescription>
                 </DialogHeader>
-                <CreateOrganizationUnitForm onSuccess={handleOrganizationCreated} />
+                <CreateOrganizationUnitForm 
+                  onSuccess={handleOrganizationCreated}
+                  onCancel={() => setIsDialogOpen(false)}
+                />
               </DialogContent>
             </Dialog>
           </>

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -42,6 +42,7 @@ interface AuthContextType {
   register: (data: RegisterRequest) => Promise<User>
   logout: () => Promise<void>
   refreshToken: () => Promise<boolean>
+  refreshUserProfile: () => Promise<void>
   updateUser: (userData: Partial<User>) => void
   hasPermission: (resource: string, requiredPermission: PermissionLevel, tenant?: string) => boolean
   error: string | null
@@ -386,6 +387,7 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
           register,
           logout,
           refreshToken,
+          refreshUserProfile: fetchAndUpdateUserProfile,
           updateUser,
           hasPermission,
           error,
@@ -400,6 +402,7 @@ export function AuthProvider({ children }: { readonly children: ReactNode }) {
           register,
           logout,
           refreshToken,
+          fetchAndUpdateUserProfile,
           updateUser,
           hasPermission,
           error,


### PR DESCRIPTION
Introduces a refreshUserProfile method to the auth context and updates TenantGuard to refresh the user profile when switching tenants. Also improves dialog state handling in the tenant selector page to close the dialog on organization creation or cancel.