### PR TITLE
Remove lastConnected field from agent components

### DIFF
--- a/src/components/agent/agent.tsx
+++ b/src/components/agent/agent.tsx
@@ -42,7 +42,6 @@ export const agentSchema = z.object({
   name: z.string(),
   machineName: z.string(),
   status: z.string(),
-  lastConnected: z.string(),
 })
 
 export type AgentRow = z.infer<typeof agentSchema>

--- a/src/components/agent/columns.tsx
+++ b/src/components/agent/columns.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { ColumnDef, Column, Row } from '@tanstack/react-table'
+import { ColumnDef } from '@tanstack/react-table'
 
 import { Checkbox } from '@/components/ui/checkbox'
 import type { AgentRow } from './agent'
 import { DataTableColumnHeader } from '@/components/layout/table/data-table-column-header'
 import DataTableRowAction from './data-table-row-actions'
-import { formatUtcToLocal } from '@/lib/utils/datetime'
 
 export const createAgentColumns = (
   onRefresh?: () => void,
@@ -87,25 +86,6 @@ export const createAgentColumns = (
           <span className={`px-2 py-1 rounded-full text-xs font-medium ${statusClass}`}>
             {status}
           </span>
-        </div>
-      )
-    },
-  },
-  {
-    accessorKey: 'lastConnected',
-    header: ({ column }: { column: Column<AgentRow> }) => (
-      <DataTableColumnHeader column={column} title="Last Connected" />
-    ),
-    cell: ({ row }: { row: Row<AgentRow> }) => {
-      const rawValue = row.getValue('lastConnected')
-      const lastConnected =
-        typeof rawValue === 'string' ? rawValue : rawValue ? String(rawValue) : null
-
-      const formattedDate = formatUtcToLocal(lastConnected, { fallback: 'Never' })
-
-      return (
-        <div className="flex items-center">
-          <span>{formattedDate}</span>
         </div>
       )
     },

--- a/src/components/agent/create-edit-modal.tsx
+++ b/src/components/agent/create-edit-modal.tsx
@@ -291,14 +291,14 @@ export function CreateEditModal({ isOpen, onClose, mode, agent, onSuccess }: Ite
               <div className="flex">
                 <Input
                   id="agent-key"
-                  value={createdAgent.machineKey}
+                  value={createdAgent.machineKey || ''}
                   readOnly
                   className="flex-1 bg-muted font-mono text-xs"
                 />
                 <Button
                   variant="ghost"
                   size="icon"
-                  onClick={() => copyToClipboard(createdAgent.machineKey, 'key')}
+                  onClick={() => copyToClipboard(createdAgent.machineKey || '', 'key')}
                   className="ml-2"
                   title="Copy Agent Key"
                 >

--- a/src/lib/api/bot-agents.ts
+++ b/src/lib/api/bot-agents.ts
@@ -9,9 +9,8 @@ export interface BotAgentResponseDto {
   id: string
   name: string
   machineName: string
-  machineKey: string
+  machineKey: string | null
   status: string
-  lastConnected: string
   isActive: boolean
 }
 


### PR DESCRIPTION
Eliminated the lastConnected property from the agent schema, columns, and API DTO to simplify the agent data model and UI. Also updated create-edit-modal to handle possible null values for machineKey.