### PR TITLE
Prevent modal close on outside click and update UI behaviors

### DIFF
--- a/run-frontend.bat
+++ b/run-frontend.bat
@@ -34,8 +34,7 @@ if not exist ".env.local" (
     echo NEXT_PUBLIC_APP_URL=http://localhost:3001
     echo NEXT_PUBLIC_APP_DOMAIN=localhost
     echo NEXT_PUBLIC_N8N_WEBHOOK_URL=
-    echo # Optional: override agent download URL
-    echo # NEXT_PUBLIC_AGENT_DOWNLOAD_URL=
+    echo NEXT_PUBLIC_AGENT_DOWNLOAD_URL=https://download.openautomate.io/OpenAutomate-Agent-Setup.exe
     ) > ".env.local"
     echo Configuration file created (.env.local)
 ) else (

--- a/src/components/administration/organization-unit/create-edit-modal.tsx
+++ b/src/components/administration/organization-unit/create-edit-modal.tsx
@@ -57,7 +57,10 @@ export function CreateEditModal({ isOpen, onClose }: ItemModalProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[800px] p-6">
+      <DialogContent
+        className="sm:max-w-[800px] p-6"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>Create new roles</DialogTitle>
         </DialogHeader>

--- a/src/components/administration/users/create-edit-modal.tsx
+++ b/src/components/administration/users/create-edit-modal.tsx
@@ -84,7 +84,10 @@ export function CreateEditModal({ isOpen, onClose }: ItemModalProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[800px] p-6">
+      <DialogContent
+        className="sm:max-w-[800px] p-6"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>Invite Users</DialogTitle>
         </DialogHeader>

--- a/src/components/automation/executions/historical/create-edit-modal.tsx
+++ b/src/components/automation/executions/historical/create-edit-modal.tsx
@@ -49,7 +49,10 @@ export function CreateEditModal({ isOpen, onClose, mode }: ItemModalProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[800px] p-6">
+      <DialogContent
+        className="sm:max-w-[800px] p-6"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>{isEditing ? 'Edit Agent' : 'Create a new Agent'}</DialogTitle>
           <DialogDescription>

--- a/src/components/automation/executions/scheduled/create-edit-modal.tsx
+++ b/src/components/automation/executions/scheduled/create-edit-modal.tsx
@@ -49,7 +49,10 @@ export function CreateEditModal({ isOpen, onClose, mode }: ItemModalProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[800px] p-6">
+      <DialogContent
+        className="sm:max-w-[800px] p-6"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>{isEditing ? 'Edit Agent' : 'Create a new Agent'}</DialogTitle>
           <DialogDescription>

--- a/src/components/automation/package/create-edit-modal.tsx
+++ b/src/components/automation/package/create-edit-modal.tsx
@@ -95,7 +95,10 @@ export function CreateEditModal({ isOpen, onClose, mode, onSuccess }: ItemModalP
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[600px] p-6">
+      <DialogContent
+        className="sm:max-w-[600px] p-6"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>{isEditing ? 'Edit Package' : 'Create New Automation Package'}</DialogTitle>
           <DialogDescription >

--- a/src/components/automation/schedule/schedule/components/TriggerTab.tsx
+++ b/src/components/automation/schedule/schedule/components/TriggerTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Calendar } from '@/components/ui/calendar'
@@ -281,19 +281,43 @@ function DatePicker({
   setIsOpen,
   minDate,
 }: DatePickerProps) {
+  const calendarRef = React.useRef<HTMLDivElement>(null)
+
+  // Handle clicks outside the calendar
+  React.useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (calendarRef.current && !calendarRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [isOpen, setIsOpen])
+
   return (
-    <div className="grid gap-2">
+    <div className="grid gap-2 relative">
       <label className="text-sm font-medium">
         {label} {required && <span className="text-red-500">*</span>}
       </label>
-      <Popover open={isOpen} onOpenChange={setIsOpen}>
-        <PopoverTrigger asChild>
-          <Button variant="outline" className="w-full justify-between font-normal">
-            {date ? date.toLocaleDateString() : 'Select date'}
-            <ChevronDownIcon className="h-4 w-4" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-auto overflow-hidden p-0" align="start">
+      <Button
+        variant="outline"
+        className="w-full justify-between font-normal"
+        onClick={() => setIsOpen(!isOpen)}
+        type="button"
+      >
+        {date ? date.toLocaleDateString() : 'Select date'}
+        <ChevronDownIcon className="h-4 w-4" />
+      </Button>
+
+      {isOpen && (
+        <div
+          ref={calendarRef}
+          className="absolute bottom-full left-0 z-[100] mb-1 bg-popover text-popover-foreground rounded-md border shadow-md"
+          style={{ zIndex: 100 }}
+        >
           <Calendar
             mode="single"
             selected={date}
@@ -308,8 +332,8 @@ function DatePicker({
               setIsOpen(false)
             }}
           />
-        </PopoverContent>
-      </Popover>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/automation/schedule/schedule/components/TriggerTab.tsx
+++ b/src/components/automation/schedule/schedule/components/TriggerTab.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+
 import { ChevronDownIcon } from 'lucide-react'
 import { RecurrenceType } from '@/lib/api/schedules'
 import type { ScheduleFormData } from '../create-edit-modal'

--- a/src/components/automation/schedule/schedule/create-edit-modal.tsx
+++ b/src/components/automation/schedule/schedule/create-edit-modal.tsx
@@ -397,7 +397,10 @@ export function CreateEditModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[800px]">
+      <DialogContent
+        className="sm:max-w-[800px]"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>{mode === 'edit' ? 'Edit Schedule' : 'Create Schedule'}</DialogTitle>
           <DialogDescription>

--- a/src/components/systemAdmin/organization-unit/create-edit-modal.tsx
+++ b/src/components/systemAdmin/organization-unit/create-edit-modal.tsx
@@ -58,7 +58,10 @@ export function CreateEditModal({ isOpen, onClose }: ItemModalProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[800px] p-6">
+      <DialogContent
+        className="sm:max-w-[800px] p-6"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>Create new roles</DialogTitle>
           <DialogDescription>

--- a/src/components/ui/enhanced-toast.tsx
+++ b/src/components/ui/enhanced-toast.tsx
@@ -65,7 +65,7 @@ export function EnhancedToast({ type, title, description, action, onClose }: Enh
         'data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)]',
         'data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none',
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out',
-        'data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full',
+        'data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-left-full',
         'data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
         'hover:shadow-xl',
         config.className,

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -26,7 +26,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[60] w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
           className,
         )}
         {...props}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:left-0 sm:top-auto sm:flex-col md:max-w-[420px]',
       className,
     )}
     {...props}
@@ -23,7 +23,7 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
 const toastVariants = cva(
-  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-left-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
   {
     variants: {
       variant: {

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -76,7 +76,7 @@ export function Toaster() {
           </Toast>
         )
       })}
-      <ToastViewport className="fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[400px]" />
+      <ToastViewport className="fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:left-0 sm:top-auto sm:flex-col md:max-w-[400px]" />
     </ToastProvider>
   )
 }


### PR DESCRIPTION
Modals across several components now prevent closing when clicking outside by adding onInteractOutside handlers. The date picker in TriggerTab was refactored to handle outside clicks without Popover, improving UX. Toast and popover components had z-index and animation direction adjustments for better consistency and positioning. The frontend run script now sets a default agent download URL.