### PR TITLE
Change default recurrence type to Once in schedule forms

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - develop
+      - main
 
 env:
   SONAR_PROJECT_KEY: openautomate-frontend

--- a/src/components/automation/schedule/page.tsx
+++ b/src/components/automation/schedule/page.tsx
@@ -764,7 +764,7 @@ export default function ScheduleInterface() {
               name: newSchedule.name,
               description: '',
               isEnabled: true,
-              recurrenceType: RecurrenceType.Daily,
+              recurrenceType: RecurrenceType.Once,
               timeZoneId: 'UTC',
               automationPackageId: '',
               botAgentId: '',

--- a/src/components/automation/schedule/schedule/create-edit-modal.tsx
+++ b/src/components/automation/schedule/schedule/create-edit-modal.tsx
@@ -107,7 +107,7 @@ export function CreateEditModal({
     agentId: editingSchedule?.agentId ?? '',
     timezone: editingSchedule?.timezone ?? 'Asia/Ho_Chi_Minh',
     recurrence: {
-      type: (editingSchedule?.recurrence?.type as RecurrenceType) ?? RecurrenceType.Daily,
+      type: (editingSchedule?.recurrence?.type as RecurrenceType) ?? RecurrenceType.Once,
       value: editingSchedule?.recurrence?.value ?? '1',
       startTime: editingSchedule?.recurrence?.startTime ?? '09:00',
       dailyHour: editingSchedule?.recurrence?.dailyHour ?? '09',
@@ -173,7 +173,7 @@ export function CreateEditModal({
         agentId: editingSchedule.agentId ?? '',
         timezone: editingSchedule.timezone ?? 'Asia/Ho_Chi_Minh',
         recurrence: {
-          type: (rec.type as RecurrenceType) ?? RecurrenceType.Daily,
+          type: (rec.type as RecurrenceType) ?? RecurrenceType.Once,
           value: rec.value ?? '1',
           startDate,
           dailyHour,
@@ -219,7 +219,7 @@ export function CreateEditModal({
         agentId: '',
         timezone: 'Asia/Ho_Chi_Minh',
         recurrence: {
-          type: RecurrenceType.Daily,
+          type: RecurrenceType.Once,
           value: '1',
           startTime: '09:00',
           dailyHour: '09',


### PR DESCRIPTION
Updated the default recurrence type from Daily to Once in both the schedule creation modal and the schedule interface. This ensures new schedules are set to run once by default instead of daily.