### PR TITLE
Show delete button only when rows are selected

### DIFF
--- a/src/components/administration/users/users.tsx
+++ b/src/components/administration/users/users.tsx
@@ -266,15 +266,16 @@ export default function UsersInterface() {
                 >
                   <PlusCircle className="mr-2 h-4 w-4" /> Invite User
                 </Button>
-                <Button
-                  variant="destructive"
-                  onClick={handleDeleteClick}
-                  className="flex items-center justify-center"
-                  disabled={Object.keys(rowSelection).length === 0}
-                >
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Delete Selected
-                </Button>
+                {Object.keys(rowSelection).length > 0 && (
+                  <Button
+                    variant="destructive"
+                    onClick={handleDeleteClick}
+                    className="flex items-center justify-center"
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Delete
+                  </Button>
+                )}
               </div>
             </>
           )}

--- a/src/components/agent/agent.tsx
+++ b/src/components/agent/agent.tsx
@@ -569,15 +569,16 @@ export default function AgentInterface() {
               <PlusCircle className="mr-2 h-4 w-4" />
               Create
             </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDeleteClick}
-              className="flex items-center justify-center"
-              disabled={Object.keys(rowSelection).length === 0}
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Delete Selected
-            </Button>
+            {Object.keys(rowSelection).length > 0 && (
+              <Button
+                variant="destructive"
+                onClick={handleDeleteClick}
+                className="flex items-center justify-center"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
+              </Button>
+            )}
           </div>
         </div>
 

--- a/src/components/asset/asset.tsx
+++ b/src/components/asset/asset.tsx
@@ -542,15 +542,16 @@ export default function AssetInterface() {
               <PlusCircle className="mr-2 h-4 w-4" />
               Create
             </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDeleteClick}
-              className="flex items-center justify-center"
-              disabled={Object.keys(rowSelection).length === 0}
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Delete Selected
-            </Button>
+            {Object.keys(rowSelection).length > 0 && (
+              <Button
+                variant="destructive"
+                onClick={handleDeleteClick}
+                className="flex items-center justify-center"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
+              </Button>
+            )}
           </div>
         </div>
 

--- a/src/components/automation/package/package.tsx
+++ b/src/components/automation/package/package.tsx
@@ -501,15 +501,16 @@ export default function PackageInterface() {
               <PlusCircle className="mr-2 h-4 w-4" />
               {t('package.create')}
             </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDeleteClick}
-              className="flex items-center justify-center"
-              disabled={Object.keys(rowSelection).length === 0}
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Delete Selected
-            </Button>
+            {Object.keys(rowSelection).length > 0 && (
+              <Button
+                variant="destructive"
+                onClick={handleDeleteClick}
+                className="flex items-center justify-center"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
+              </Button>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
Updated user, agent, asset, and package interfaces to conditionally render the delete button only when at least one row is selected. This improves the UI by hiding the destructive action when it is not applicable and simplifies the button label from 'Delete Selected' to 'Delete'.