### PR TITLE
Show delete button only when rows are selected

### DIFF
--- a/src/components/automation/schedule/page.tsx
+++ b/src/components/automation/schedule/page.tsx
@@ -883,15 +883,16 @@ export default function ScheduleInterface() {
               <PlusCircle className="mr-2 h-4 w-4" />
               {t('schedule.createSchedule')}
             </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDeleteClick}
-              className="flex items-center justify-center"
-              disabled={Object.keys(rowSelection).length === 0}
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              Delete Selected
-            </Button>
+            {Object.keys(rowSelection).length > 0 && (
+              <Button
+                variant="destructive"
+                onClick={handleDeleteClick}
+                className="flex items-center justify-center"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
+              </Button>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
The delete button is now conditionally rendered and only appears when at least one row is selected, improving the user interface by removing the need for a disabled state.